### PR TITLE
get the current gas price via web3js

### DIFF
--- a/packages/o-circles/src/rpcGateway.ts
+++ b/packages/o-circles/src/rpcGateway.ts
@@ -8,7 +8,7 @@ import {Observable} from "rxjs";
 export class RpcGateway {
     static readonly gateways = [
         "wss://rpc.circles.land/",
-        //"wss://circles-xdai-rpc.lab10.io/wss"
+        // "wss://circles-xdai-rpc.lab10.io/wss"
     ];
 
     private static _lastProviderUrl?: string;
@@ -126,8 +126,11 @@ export class RpcGateway {
         );
     }
 
-    static getGasPrice() {
-        return new BN(this.get().utils.toWei("1", "gwei"))
+    static async getGasPrice() {
+        const gasPrice = await this._web3?.eth.getGasPrice();
+        if (!gasPrice)
+            throw new Error(`Cannot determine the gasPrice (_web3 not set?)`)
+        return new BN(gasPrice);
     }
 
     static rotateProvider() {

--- a/packages/o-circles/src/web3Contract.ts
+++ b/packages/o-circles/src/web3Contract.ts
@@ -153,7 +153,7 @@ export abstract class Web3Contract {
         const nonce = "0x" + Web3.utils.toBN(await web3.eth.getTransactionCount(ownerAddress)).toString("hex");
 
         const rawTx: TxData = {
-            gasPrice: "0x" + new BN(RpcGateway.getGasPrice()).toString("hex"),
+            gasPrice: "0x" + (await RpcGateway.getGasPrice()).toString("hex"),
             gasLimit: "0x" + gasLimit.toString("hex"),
             to: to,
             value: "0x" + value.toString("hex"),


### PR DESCRIPTION
Transactions can take a very long time to complete because the gas price was fixed to 1. This patch changes this behavior and always gets the current gas price for each transaction. 