### PR TITLE
add: CI container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.vscode
+container
+

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -5,7 +5,7 @@ ARG SERVER_COMMIT
 
 ARG APP_ID=${SERVER_COMMIT}.dev.circles.land
 ARG EXTERNAL_URL=https://${APP_ID}
-ARG API_ENDPOINT=${SERVER_COMMIT}.dev.api.circles.land
+ARG API_ENDPOINT=https://${SERVER_COMMIT}.dev.api.circles.land
 
 ARG RPC_ENDPOINT=https://rpc.circles.land
 ARG AUTH_ENDPOINT=https://dev.auth.circles.name

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,35 @@
+FROM node:16 as build
+
+ARG DEPLOY_ENVIRONMENT=ci
+ARG SERVER_COMMIT
+
+ARG APP_ID=${SERVER_COMMIT}.dev.circles.land
+ARG EXTERNAL_URL=https://${APP_ID}
+ARG API_ENDPOINT=${SERVER_COMMIT}.dev.api.circles.land
+
+ARG RPC_ENDPOINT=https://rpc.circles.land
+ARG AUTH_ENDPOINT=https://dev.auth.circles.name
+
+ARG CIRCLES_HUB_ADDRESS=0x29b9a7fBb8995b2423a71cC17cf9810798F6C543
+ARG CIRCLES_HUB_BLOCK=12529458
+ARG SAFE_PROXY_FACTORY_ADDRESS=0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2
+ARG SAFE_ADDRESS=0x3E5c63644E683549055b9Be8653de26E0B4CD36E
+
+ARG FILES_APP_ID=dev.files.circles.land
+ARG HUMANODE_CLIENT_ID=circles-ubi-staging
+ARG SHOW_LANGUAGE_SWITCHER=false
+
+RUN echo "${DEPLOY_ENVIRONMENT}" ; \
+    echo "${SERVER_COMMIT}"      ; \
+    echo "${APP_ID}"             ; \
+    echo "${EXTERNAL_URL}"       ; \
+    echo "${API_ENDPOINT}"
+
+COPY . /o-platform
+WORKDIR /o-platform
+RUN ./build.sh ${DEPLOY_ENVIRONMENT} ${API_ENDPOINT}
+
+FROM nginx:stable-alpine as server
+COPY --from=build /o-platform/shell/public /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/container/container-compose.ci.yaml
+++ b/container/container-compose.ci.yaml
@@ -7,4 +7,3 @@ services:
       dockerfile: Dockerfile.ci
       args:
         SERVER_COMMIT: ${SERVER_COMMIT}
-    expose: "80"

--- a/container/container-compose.ci.yaml
+++ b/container/container-compose.ci.yaml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfile.ci
+      args:
+        SERVER_COMMIT: ${SERVER_COMMIT}
+    expose: "80"

--- a/shell/webpack.config.js
+++ b/shell/webpack.config.js
@@ -90,6 +90,23 @@ if (process.env.DEPLOY_ENVIRONMENT === "main") {
   __FIXED_GAS_PRICE__ = "1";
   __HUMANODE_CLIENT_ID__ = "circles-ubi-staging";
   prod = false;
+} else if (process.env.DEPLOY_ENVIRONMENT === "ci") {
+  __APP_ID__ = process.env.APP_ID;
+  __EXTERNAL_URL__ = process.env.EXTERNAL_URL;
+
+  __API_ENDPOINT__ = process.env.API_ENDPOINT;
+  __RPC_ENDPOINT__ = process.env.RPC_ENDPOINT;
+  __AUTH_ENDPOINT__ = process.env.AUTH_ENDPOINT;
+
+  __CIRCLES_HUB_ADDRESS__ = process.env.CIRCLES_HUB_ADDRESS;
+  __CIRCLES_HUB_BLOCK__ = process.env.CIRCLES_HUB_BLOCK;
+  __SAFE_PROXY_FACTORY_ADDRESS__ = process.env.SAFE_PROXY_FACTORY_ADDRESS;
+  __SAFE_ADDRESS__ = process.env.SAFE_ADDRESS;
+
+  __FILES_APP_ID__ = process.env.FILES_APP_ID;
+  __HUMANODE_CLIENT_ID__ = process.env.HUMANODE_CLIENT_ID;
+  __SHOW_LANGUAGE_SWITCHER__ = process.env.SHOW_LANGUAGE_SWITCHER;
+  prod = false;
 }
 
 __HUMANODE_REDIRECT_URL__ = __EXTERNAL_URL__;


### PR DESCRIPTION
This is the first step towards client development deployment targeting specific development API server.

- https://circlesland.fibery.io/Platform/Remediation/Client-development-deployment-targeting-specific-development-API-server-59

It adds

- a Dockerfile for CI
- a Compose example
- a fully configurable `ci` `DEPLOY_ENVIRONMENT` to `webpack.config.js`

---

This was tested locally with [`podman-compose`](https://pypi.org/project/podman-compose/):

```shell
cd container
echo "SERVER_COMMIT=cf79a81" > .env
podman-compose -f container-compose.ci.yaml build app
```

and should work similarily with other container runtimes and other Compose interpreters.